### PR TITLE
Dotbot utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ Run a dotbot profile script from `dotfiles/meta/profiles/` folder
 [Available profiles](./meta/profiles)
 
 ```bash
-./install-profile <profile>
+./install-profile <profile ...>
 ```
+
+Ex:
+```bash
+./install-profile debian-terminal debian-gui # debian terminal and gui configs
+```
+
+---
 
 #### MacOS
 

--- a/install-profile
+++ b/install-profile
@@ -37,6 +37,22 @@ cd "${BASE_DIR}"
 git submodule update --init --recursive
 
 # ------------------------------------------------------------------------------------------------ #
+# Utility functions
+
+# print line banner
+# used for segmenting when a profile configs is being executed.
+# For VISUAL purposes
+printLineBanner() {
+  # print a line depending on the terminal width
+  # https://unix.stackexchange.com/a/425158
+  # https://stackoverflow.com/a/17030976/3053548
+  #
+  # print ANSI color using printf
+  # https://stackoverflow.com/a/26873040/3053548
+  printf '\e[1;34m%0.s#\e[0m' $(seq 1 $(stty size | awk '{print $2}'))
+}
+
+# ------------------------------------------------------------------------------------------------ #
 # Verify dotbot profile exists
 # Checks if the file exists in meta/profiles/ folder
 
@@ -74,6 +90,11 @@ for profile in ${@}; do
   while IFS= read -r config; do
     CONFIGS+=" ${config}"
   done < "${META_DIR}/${PROFILES_DIR}/$profile"
+
+  # print line banner multiple times
+  # https://serverfault.com/a/273241
+  for i in `seq 2`; do printLineBanner; done
+  echo -e "\nRunning profile \e[1;34m$profile\e[0m\n"
 
   # run dotbot configs
   source ./install-standalone ${CONFIGS}

--- a/install-profile
+++ b/install-profile
@@ -89,7 +89,10 @@ for profile in ${@}; do
   # extract dotbot configs to run
   while IFS= read -r config; do
     CONFIGS+=" ${config}"
-  done < "${META_DIR}/${PROFILES_DIR}/$profile"
+
+  # read lines that DON'T start with #
+  # obtained from https://stackoverflow.com/a/8197412/3053548
+  done < <(grep -v '^#' "${META_DIR}/${PROFILES_DIR}/$profile")
 
   # print line banner multiple times
   # https://serverfault.com/a/273241

--- a/install-profile
+++ b/install-profile
@@ -66,12 +66,20 @@ unset exitIfProfileNotFound
 
 # ------------------------------------------------------------------------------------------------ #
 
-while IFS= read -r config; do
-  CONFIGS+=" ${config}"
-done < "${META_DIR}/${PROFILES_DIR}/$1"
+# loop through each argument
+#   extract dotbot configs to run
+#   run dotbot configs using ./install-standalone
+for profile in ${@}; do
+  # extract dotbot configs to run
+  while IFS= read -r config; do
+    CONFIGS+=" ${config}"
+  done < "${META_DIR}/${PROFILES_DIR}/$profile"
 
-shift
+  # run dotbot configs
+  source ./install-standalone ${CONFIGS}
 
-source ./install-standalone ${CONFIGS}
+  # cleanup variables
+  unset CONFIGS
+done
 
 cd "${BASE_DIR}"

--- a/install-profile
+++ b/install-profile
@@ -36,6 +36,35 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "${BASE_DIR}"
 git submodule update --init --recursive
 
+# ------------------------------------------------------------------------------------------------ #
+# Verify dotbot profile exists
+# Checks if the file exists in meta/profiles/ folder
+
+exitIfProfileNotFound=false    # used as a flag to exit IF a profile is NOT found
+for profile in ${@}; do
+  # check if the profile filepath doesn't exist
+  #   print message
+  #   flag variable to exit
+
+  profileFilepath="${BASE_DIR}/${META_DIR}/${PROFILES_DIR}/${profile}"
+
+  if [[ ! -e $profileFilepath ]]; then
+    echo -e "Dotbot profile \\033[1;31m$profileFilepath \\033[0mNOT found"
+
+    exitIfProfileNotFound=true
+  fi
+done
+
+# exit if a profile filepath is NOT found
+if [[ $exitIfProfileNotFound == true ]]; then
+  echo -e "\nexiting"
+  exit 1
+fi
+
+# cleanup variables
+unset exitIfProfileNotFound
+
+# ------------------------------------------------------------------------------------------------ #
 
 while IFS= read -r config; do
   CONFIGS+=" ${config}"

--- a/install-standalone
+++ b/install-standalone
@@ -42,6 +42,42 @@ git submodule update --init --recursive
 # load XDG dotfile locations. https://wiki.archlinux.org/title/XDG_Base_Directory
 source tools/zsh/.zshenv
 
+# ------------------------------------------------------------------------------------------------ #
+# Verify dotbot config files exist.
+# Also checks if the config file exists if it has a suffix of '-sudo'. Ex: apt-sudo
+# Checks if the file exists in meta/configs/ folder
+
+sudoSuffix="-sudo"
+exitIfConfigNotFound=false    # used as a flag to exit IF a config file is NOT found
+for config in ${@}; do
+  # remove suffix '-sudo' in the variable $config
+  # check if the config filepath doesn't exist
+  #   print message
+  #   flag variable to exit
+
+  # remove suffix '-sudo'
+  # obtained from https://stackoverflow.com/a/16623897/3053548
+  config=${config%"$sudoSuffix"}
+  configFilepath="${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${config}${CONFIG_SUFFIX}"
+  if [[ ! -e $configFilepath ]]; then
+    echo -e "Dotbot config \\033[1;31m$configFilepath \\033[0mDOESN'T exists"
+
+    exitIfConfigNotFound=true
+  fi
+done
+
+# exit if a config filepath is NOT found
+if [[ $exitIfConfigNotFound == true ]]; then
+  echo -e "\nexiting"
+  exit 1
+fi
+
+# cleanup variables
+unset sudoSuffix
+unset exitIfConfigNotFound
+
+# ------------------------------------------------------------------------------------------------ #
+
 for config in ${@}; do
   # create temporary file
   configFile="$(mktemp)"

--- a/meta/install-list/dnf
+++ b/meta/install-list/dnf
@@ -38,6 +38,7 @@ trash-cli
 tree
 ufw
 unzip
+util-linux-user
 vim
 wget
 zip

--- a/meta/profiles/README.md
+++ b/meta/profiles/README.md
@@ -36,7 +36,6 @@ git
 tmux
 alacritty
 spacevim
-
 ```
 
 #### Example: config with sudo
@@ -48,8 +47,22 @@ apt-sudo
 git
 neovim-precompiled-sudo
 neovim-packages
-
 ```
+
+### ignoring dotbot configs
+
+If you wish to ignore certain dotbot configs, add `#` at the beginning of the line you wish to ignore
+
+Ex:
+
+```bash
+apt-sudo
+# git
+neovim-precompiled-sudo
+# neovim-packages
+```
+
+This will only run `apt-sudo` and `neovim-precompiled-sudo`
 
 ---
 
@@ -62,7 +75,7 @@ If you wish to run a profile, then run the following command.
 - NOTE: run the script from repo home folder `dotfiles/`. **NOT** `dotfiles/meta/profiles/`
 
 ```bash
-./install-profile <profile>
+./install-profile <profile ...>
 ```
 
 Ex:
@@ -73,6 +86,10 @@ Ex:
 
 ```bash
 ./install-profile raspberrypi-pihole
+```
+
+```bash
+./install-profile debian-terminal debian-gui
 ```
 
 ---

--- a/meta/profiles/debian-gui
+++ b/meta/profiles/debian-gui
@@ -1,3 +1,13 @@
+#!/bin/bash
+# 
+# NOTE: this not to be run by bash.
+#       this is ONLY used for reading the file contents.
+#       the shebang is used by VScode for syntax highlighting
+#       file is read using 'install-profile'
+# a list of dotbot config to run
+# 
+# to omit a config from being run, add # at the beginning of the line
+
 apt-gui-sudo
 alacritty
 vscode-debian-sudo

--- a/meta/profiles/debian-terminal
+++ b/meta/profiles/debian-terminal
@@ -1,3 +1,13 @@
+#!/bin/bash
+# 
+# NOTE: this not to be run by bash.
+#       this is ONLY used for reading the file contents.
+#       the shebang is used by VScode for syntax highlighting
+#       file is read using 'install-profile'
+# a list of dotbot config to run
+# 
+# to omit a config from being run, add # at the beginning of the line
+
 fix-locale-sudo
 apt-sudo
 git

--- a/meta/profiles/fedora-gui
+++ b/meta/profiles/fedora-gui
@@ -1,3 +1,13 @@
+#!/bin/bash
+# 
+# NOTE: this not to be run by bash.
+#       this is ONLY used for reading the file contents.
+#       the shebang is used by VScode for syntax highlighting
+#       file is read using 'install-profile'
+# a list of dotbot config to run
+# 
+# to omit a config from being run, add # at the beginning of the line
+
 dnf-gui-sudo
 alacritty
 vscode-fedora-sudo

--- a/meta/profiles/fedora-terminal
+++ b/meta/profiles/fedora-terminal
@@ -1,3 +1,13 @@
+#!/bin/bash
+# 
+# NOTE: this not to be run by bash.
+#       this is ONLY used for reading the file contents.
+#       the shebang is used by VScode for syntax highlighting
+#       file is read using 'install-profile'
+# a list of dotbot config to run
+# 
+# to omit a config from being run, add # at the beginning of the line
+
 dnf-copr-sudo
 dnf-sudo
 git

--- a/meta/profiles/macos
+++ b/meta/profiles/macos
@@ -1,3 +1,13 @@
+#!/bin/bash
+# 
+# NOTE: this not to be run by bash.
+#       this is ONLY used for reading the file contents.
+#       the shebang is used by VScode for syntax highlighting
+#       file is read using 'install-profile'
+# a list of dotbot config to run
+# 
+# to omit a config from being run, add # at the beginning of the line
+
 homebrew
 git
 tmux

--- a/meta/profiles/raspberrypi-pihole
+++ b/meta/profiles/raspberrypi-pihole
@@ -1,3 +1,13 @@
+#!/bin/bash
+# 
+# NOTE: this not to be run by bash.
+#       this is ONLY used for reading the file contents.
+#       the shebang is used by VScode for syntax highlighting
+#       file is read using 'install-profile'
+# a list of dotbot config to run
+# 
+# to omit a config from being run, add # at the beginning of the line
+
 raspberrypi-configs-sudo
 debian-apt-sources-sudo
 apt-sudo


### PR DESCRIPTION
- `install-standalone`
  - [x] verify dotbot config exists before executing
  - [x] display error and exit if dotbot config doesn't exist
- `install-profile`
  - [x] verify dotbot profile exists before executing
  - [x] display error and exit if dotbot profile doesn't exist
  - [x] add functionality to omit a dotbot config from executing in a dotbot profile. Ex: commenting out a line a dotbot profile
- [x] update docs